### PR TITLE
DATA-3780: Update documentation to show dbt config

### DIFF
--- a/datacontract/templates/datacontract.html
+++ b/datacontract/templates/datacontract.html
@@ -145,8 +145,19 @@
                       {% for field_name, field in model.fields.items() %}
                         {{ render_partial('partials/model_field.html', nested = False, field_name=field_name, field = field, level = 0) }}
                       {% endfor %}
+                      {% if model.ephemerals %}
+                      <tr class="bg-gray-50">
+                        <th scope="colgroup" colspan="4"
+                            class="py-2 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                          <span>Ephemerals</span>
+                        </th>
+                      </tr>
+                        {% for field_name, field in model.ephemerals.items() %}
+                          {{ render_partial('partials/model_field.html', nested = False, field_name=field_name, field = field, level = 0) }}
+                        {% endfor %}
+                      {% endif %}                    
                       </tbody>
-                      {% if model.primaryKey or model.quality %}
+                      {% if model.primaryKey or model.quality or model.dbt %}
                       <tfoot class="divide-y divide-gray-200 bg-white">
                       {% if model.quality %}
                       {% for quality in model.quality %}
@@ -164,6 +175,15 @@
                         <th scope="colgroup" colspan="4"
                             class="py-2 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
                           <span>Primary Key: {{ model.primaryKey }}</span>
+                        </th>
+                      </tr>
+                      {% endif %}
+
+                      {% if model.dbt %}
+                      <tr class="bg-gray-50">
+                        <th scope="colgroup" colspan="4"
+                            class="py-2 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                          {{ render_partial('partials/model_dbt.html', dbt = model.dbt)}}
                         </th>
                       </tr>
                       {% endif %}

--- a/datacontract/templates/partials/field_dbt.html
+++ b/datacontract/templates/partials/field_dbt.html
@@ -1,0 +1,37 @@
+<div class="text-gray-400">DBT Configuration:</div>
+
+{% if dbt.enabled %}
+<div class="text-gray-400" style="padding-left: 10px;">Enabled: {{ dbt.enabled }}</div>
+{% endif %}
+  
+{% if dbt.index >= 0 %}
+<div class="text-gray-400" style="padding-left: 10px;">Index: {{ dbt.index }}</div>
+{% endif %}
+
+{% if dbt.calculation %}
+<div class="text-gray-400" style="padding-left: 10px;">Calculation: {{ dbt.calculation }}</div>
+{% endif %}
+
+{% if dbt.pivot %}
+<div class="text-gray-400" style="padding-left: 10px;">Pivot: {{ dbt.pivot }}</div>
+{% endif %}
+
+{% if dbt.pivotKeyField %}
+<div class="text-gray-400" style="padding-left: 10px;">Pivot Key Field: {{ dbt.pivotKeyField }}</div>
+{% endif %}
+
+{% if dbt.pivotKeyFilter %}
+<div class="text-gray-400" style="padding-left: 10px;">Pivot Key Filter: {{ dbt.pivotKeyFilter }}</div>
+{% endif %}
+
+{% if dbt.pivotValueField %}
+<div class="text-gray-400" style="padding-left: 10px;">Pivot Value Field: {{ dbt.pivotValueField }}</div>
+{% endif %}
+
+{% if dbt.security %}
+<div class="text-gray-400" style="padding-left: 10px;">Security: {{ dbt.security }}</div>
+{% endif %}
+
+{% if dbt.bigqueryType %}
+<div class="text-gray-400" style="padding-left: 10px;">BigQuery Type: {{ dbt.bigqueryType }}</div>
+{% endif %}

--- a/datacontract/templates/partials/model_dbt.html
+++ b/datacontract/templates/partials/model_dbt.html
@@ -1,0 +1,61 @@
+<div class=" px-4 sm:px-0">
+  <p class="text-sm text-gray-500">DBT Configuration:</p>
+</div>
+
+  <div class="px-4 py-2 sm:px-6">
+
+      {% if dbt.enabled %}
+      <div class="text-gray-400" style="padding-left: 10px;">Enabled: {{ dbt.enabled }}</div>
+      {% endif %}
+
+      {% if dbt.typeOverwrite %}
+      <div class="text-gray-400" style="padding-left: 10px;">Type Overwrite: {{ dbt.typeOverwrite }}</div>
+      {% endif %}
+
+      {% if dbt.snapshot %}
+      <div class="text-gray-400" style="padding-left: 10px;">Snapshot: {{ dbt.snapshot }}</div>
+      {% endif %}
+
+      {% if dbt.deduplicate %}
+      <div class="text-gray-400" style="padding-left: 10px;">Deduplicate: {{ dbt.deduplicate }}</div>
+      {% endif %}
+
+      {% if dbt.orderBy %}
+      <div class="text-gray-400" style="padding-left: 10px;">Order By: {{ dbt.orderBy }}</div>
+      {% endif %}
+
+      {% if dbt.clusterBy %}
+      <div class="text-gray-400" style="padding-left: 10px;">Cluster By: {{ dbt.clusterBy }}</div>
+      {% endif %}
+
+      {% if dbt.incremental %}
+      <div class="text-gray-400" style="padding-left: 10px;">Incremental: {{ dbt.incremental }}</div>
+      {% endif %}
+
+      {% if dbt.security %}
+      <div class="text-gray-400" style="padding-left: 10px;">Security: {{ dbt.security }}</div>
+      {% endif %}
+
+      {% if dbt.partitionExpirationDays %}
+      <div class="text-gray-400" style="padding-left: 10px;">Partition Expiration: {{ dbt.partitionExpirationDays }}</div>
+      {% endif %}
+
+      {% if dbt.recencyThreshold %}
+      <div class="text-gray-400" style="padding-left: 10px;">Recency Threshold: {{ dbt.recencyThreshold }}</div>
+      {% endif %}
+
+      {% if dbt.recencyField %}
+      <div class="text-gray-400" style="padding-left: 10px;">Recency Field: {{ dbt.recencyField }}</div>
+      {% endif %}
+
+      {% if dbt.filters %}
+      <div class="text-gray-400" style="padding-left: 10px;">Filters:
+        {% for filter in dbt.filters %}
+        <div style="padding-left: 10px;">
+          {{ filter.field }} {{ filter.operator }} {% if filter.value %}{{ filter.value }}{% endif %} {% if filter.dev_only %}[DEV only]{% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+</div>

--- a/datacontract/templates/partials/model_field.html
+++ b/datacontract/templates/partials/model_field.html
@@ -116,8 +116,13 @@
     {{ render_partial('partials/quality.html', quality = quality) }}
     {% endfor %}
     {% endif %}
+        
+    {% if field.dbt %}
+    {{ render_partial('partials/field_dbt.html', dbt=field.dbt) }}
+    {% endif %}
   </td>
 </tr>
+
 
 {% macro render_nested_partial(field_name, field, level) %}
 {{ render_partial('partials/model_field.html', nested=True, field_name=field_name, field=field, level=level + 1) }}

--- a/datacontract/templates/partials/server.html
+++ b/datacontract/templates/partials/server.html
@@ -207,3 +207,20 @@
   {% endfor %}
 
 </li>
+
+
+{% if server.ephemerals %}
+<table class="min-w-full divide-y divide-gray-300">
+  <tbody class="divide-y divide-gray-200 bg-white">
+  <tr class="bg-gray-50">
+    <th scope="colgroup" colspan="4"
+        class="py-2 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+      <span>Ephemerals</span>
+    </th>
+  </tr>
+  {% for field_name, field in server.ephemerals.items() %}
+    {{ render_partial('partials/model_field.html', nested = False, field_name=field_name, field = field, level = 0) }}
+  {% endfor %}                 
+  </tbody>
+</table>  
+{% endif %}


### PR DESCRIPTION
This pull request includes several changes to the `datacontract` templates to add support for displaying DBT (Data Build Tool) configuration and ephemeral fields. The most important changes include the addition of new sections for DBT configuration and ephemeral fields in multiple templates, and the creation of new partial templates to handle DBT configurations.

### Enhancements to templates:

* Added a new section for ephemeral fields in `datacontract.html` to display ephemeral fields if they exist in the model.
* Added a new section to display DBT configuration in `datacontract.html` if it exists in the model.
* Created a new partial template `field_dbt.html` to render DBT configuration details for fields.
* Created a new partial template `model_dbt.html` to render DBT configuration details for models.
* Updated `model_field.html` to include DBT configuration details for fields if they exist.
* Added a new section for ephemeral fields in `server.html` to display ephemeral fields if they exist in the server.